### PR TITLE
fix: duplicate bibliography key

### DIFF
--- a/doc/06-References.bib
+++ b/doc/06-References.bib
@@ -304,7 +304,7 @@
   doi = {10.48550/arXiv.1610.00155}
 }
 
-@article{haverkort_2010,
+@article{haverkort_2010131,
   title = {Locality and bounding-box quality of two-dimensional space-filling curves},
   journal = {Computational Geometry},
   volume = {43},


### PR DESCRIPTION
This issue was found by Typst, while making the Typst conversion PR at https://github.com/jakubcerveny/gilbert-paper/pull/10